### PR TITLE
Register Ajax Front Controller at install

### DIFF
--- a/ps_shoppingcart.php
+++ b/ps_shoppingcart.php
@@ -48,6 +48,7 @@ class Ps_Shoppingcart extends Module implements WidgetInterface
         $this->displayName = $this->getTranslator()->trans('Shopping cart', array(), 'Modules.ShoppingCart.Admin');
         $this->description = $this->getTranslator()->trans('Adds a block containing the customer\'s shopping cart.', array(), 'Modules.ShoppingCart.Admin');
         $this->ps_versions_compliancy = array('min' => '1.7.0.0', 'max' => _PS_VERSION_);
+        $this->controllers = array('ajax');
     }
 
     public function hookHeader()


### PR DESCRIPTION
The module forgets to install the ajax controller. This leads to a bug where PrestaShop 1.7 cannot always add the product to the cart. 