### PR TITLE
Fixed hook on which the module is installed

### DIFF
--- a/ps_shoppingcart.php
+++ b/ps_shoppingcart.php
@@ -141,7 +141,7 @@ class Ps_Shoppingcart extends Module implements WidgetInterface
         return
             parent::install()
                 && $this->registerHook('header')
-                && $this->registerHook('displayTop')
+                && $this->registerHook('displayNav2')
                 && Configuration::updateValue('PS_BLOCK_CART_AJAX', 1)
                 && Configuration::updateValue('PS_BLOCK_CART_XSELL_LIMIT', 12)
                 && Configuration::updateValue('PS_BLOCK_CART_SHOW_CROSSSELLING', 1)


### PR DESCRIPTION
Hi,

This PR fixes hook on which the module is installed (displayNav2 instead of displayTop).
Related forge ticket : http://forge.prestashop.com/browse/BOOM-1913

Thanks,