### PR TITLE
Fix replaceWith from the Ajax request

### DIFF
--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -45,7 +45,7 @@ $(document).ready(function () {
         }
 
         $.post(refreshURL, requestData).then(function (resp) {
-          $('.blockcart').replaceWith($(resp.preview).find('.blockcart'));
+          $('.blockcart').replaceWith(resp.preview);
           if (resp.modal) {
             showModal(resp.modal);
           }


### PR DESCRIPTION
The replacement of the `html tag` was removing the blockcart from the dom. 
After has been removed the next time we called the modal `add-to-cart` the app fail because `refreshURL` couldn't retrieve the url from the dom.

This Bug was introduced in the previous PR

https://github.com/PrestaShop/ps_shoppingcart/pull/9