### PR TITLE
Fix Mixed-content issue when on cart page with SSL

### DIFF
--- a/ps_shoppingcart.php
+++ b/ps_shoppingcart.php
@@ -70,7 +70,10 @@ class Ps_Shoppingcart extends Module implements WidgetInterface
             $this->context->language->id,
             array(
                 'action' => 'show'
-            )
+            ),
+            false,
+            null,
+            true
         );
     }
 
@@ -80,7 +83,7 @@ class Ps_Shoppingcart extends Module implements WidgetInterface
 
         return array(
             'cart' => (new CartPresenter)->present(isset($params['cart']) ? $params['cart'] : $this->context->cart),
-            'refresh_url' => $this->context->link->getModuleLink('ps_shoppingcart', 'ajax'),
+            'refresh_url' => $this->context->link->getModuleLink('ps_shoppingcart', 'ajax', array(), null, null, null, true),
             'cart_url' => $cart_url
         );
     }


### PR DESCRIPTION
This PR fixes an issue when we enable the SSL partially on PrestaShop and we try to modify our cart before checkout.

![capture du 2017-03-22 17-48-12](https://cloud.githubusercontent.com/assets/6768917/24212632/e4c58042-0f27-11e7-8f9a-bbee936af5db.png)
