### PR TITLE
Fix cart modal when a customized product is added to cart

### DIFF
--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -38,8 +38,9 @@ class Ps_ShoppingcartAjaxModuleFrontController extends ModuleFrontController
         if (Tools::getValue('action') === 'add-to-cart') {
             $modal = $this->module->renderModal(
                 $this->context->cart,
-                Tools::getValue('id_product'),
-                Tools::getValue('id_product_attribute')
+                (int)Tools::getValue('id_product'),
+                (int)Tools::getValue('id_product_attribute'),
+                (int)Tools::getValue('id_customization')
             );
         }
 

--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -38,7 +38,7 @@ $(document).ready(function () {
 
         if (event && event.reason) {
           requestData = {
-            id_customization: $('#product_customization_id').val(),
+            id_customization: event.reason.idCustomization,
             id_product_attribute: event.reason.idProductAttribute,
             id_product: event.reason.idProduct,
             action: event.reason.linkAction

--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -38,6 +38,7 @@ $(document).ready(function () {
 
         if (event && event.reason) {
           requestData = {
+            id_customization: $('#product_customization_id').val(),
             id_product_attribute: event.reason.idProductAttribute,
             id_product: event.reason.idProduct,
             action: event.reason.linkAction

--- a/ps_shoppingcart.php
+++ b/ps_shoppingcart.php
@@ -98,12 +98,14 @@ class Ps_Shoppingcart extends Module implements WidgetInterface
         return $this->fetch('module:ps_shoppingcart/ps_shoppingcart.tpl');
     }
 
-    public function renderModal(Cart $cart, $id_product, $id_product_attribute)
+    public function renderModal(Cart $cart, $id_product, $id_product_attribute, $id_customization)
     {
         $data = (new CartPresenter)->present($cart);
         $product = null;
         foreach ($data['products'] as $p) {
-            if ($p['id_product'] == $id_product && $p['id_product_attribute'] == $id_product_attribute) {
+            if ((int)$p['id_product'] == $id_product &&
+                (int)$p['id_product_attribute'] == $id_product_attribute &&
+                (int)$p['id_customization'] == $id_customization) {
                 $product = $p;
                 break;
             }


### PR DESCRIPTION
When a customized product is added, the modal dialog shows the quantity of the non customized product quantity
Here's how to reproduce:
- Add a non customized product to cart (quantity = 2 for example)
- Add the same product but after saving a customization and setting the qty to 3
- The modal shows up and displays quantity: 2
