### PR TITLE
Fix ps_shoppingcart.js removing cart menu from header

### DIFF
--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -45,7 +45,8 @@ $(document).ready(function () {
         }
 
         $.post(refreshURL, requestData).then(function (resp) {
-          $('.blockcart').replaceWith($(resp.preview).find('.blockcart'));
+          var html = $('<div />').append($.parseHTML(resp.preview));
+          $('.blockcart').replaceWith(html.find('.blockcart'));
           if (resp.modal) {
             showModal(resp.modal);
           }


### PR DESCRIPTION
This pull request fixes an error with ps_shoppingcart.js which assumes jQuery can correctly parse the content of ```resp.preview``` as html but instead it returns an array so ```.find('.blockcart')``` would never work thus replacing ```$('.blockcart')``` with an empty string.