### PR TITLE
BO: added hook displayNav2

### DIFF
--- a/ps_shoppingcart.php
+++ b/ps_shoppingcart.php
@@ -138,6 +138,7 @@ class Ps_Shoppingcart extends Module implements WidgetInterface
             parent::install()
                 && $this->registerHook('header')
                 && $this->registerHook('displayTop')
+                && $this->registerHook('displayNav2')
                 && Configuration::updateValue('PS_BLOCK_CART_AJAX', 1)
         ;
     }


### PR DESCRIPTION
In config of starter theme , ps_shoppingcart the defaukt hook is displayNav2

Questions | Answers
-- | --
Branch? | 1.7.x
Description? | added hook displayNav2
Type? | bug fix
Category? | FO
BC breaks? | no
Deprecations? | no
Fixed ticket? |
How to test? | move ps_shoppingcart to displayNav2

