### PR TITLE
Fix missing call to parent::initContent()

### DIFF
--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -33,6 +33,8 @@ class Ps_ShoppingcartAjaxModuleFrontController extends ModuleFrontController
     */
     public function initContent()
     {
+        parent::initContent();
+
         $modal = null;
 
         if (Tools::getValue('action') === 'add-to-cart') {


### PR DESCRIPTION
Fixes https://github.com/PrestaShop/PrestaShop/issues/10638

This is needed in order to have general purpose variables available in the smarty template.