### PR TITLE
The modal "add to cart confirmation" is not displayed on error

### DIFF
--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -35,7 +35,6 @@ $(document).ready(function () {
       function (event) {
         var refreshURL = $('.blockcart').data('refresh-url');
         var requestData = {};
-
         if (event && event.reason && !event.resp.hasError) {
           requestData = {
             id_product_attribute: event.reason.idProductAttribute,
@@ -51,6 +50,9 @@ $(document).ready(function () {
           }).fail(function (resp) {
             prestashop.emit('handleError', { eventType: 'updateShoppingCart', resp: resp });
           });
+        }
+        if (event && event.resp && event.resp.hasError) {
+          $('#product-availability').html('<i class="material-icons product-unavailable">&#xE14B;</i>' + event.resp.errors.join('<br/>'));
         }
       }
     );

--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -36,22 +36,22 @@ $(document).ready(function () {
         var refreshURL = $('.blockcart').data('refresh-url');
         var requestData = {};
 
-        if (event && event.reason) {
+        if (event && event.reason && !event.resp.hasError) {
           requestData = {
             id_product_attribute: event.reason.idProductAttribute,
             id_product: event.reason.idProduct,
             action: event.reason.linkAction
           };
-        }
 
-        $.post(refreshURL, requestData).then(function (resp) {
-          $('.blockcart').replaceWith($(resp.preview).find('.blockcart'));
-          if (resp.modal) {
-            showModal(resp.modal);
-          }
-        }).fail(function (resp) {
-          prestashop.emit('handleError', {eventType: 'updateShoppingCart', resp: resp});
-        });
+          $.post(refreshURL, requestData).then(function (resp) {
+            $('.blockcart').replaceWith($(resp.preview).find('.blockcart'));
+            if (resp.modal) {
+              showModal(resp.modal);
+            }
+          }).fail(function (resp) {
+            prestashop.emit('handleError', { eventType: 'updateShoppingCart', resp: resp });
+          });
+        }
       }
     );
   });

--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -52,7 +52,7 @@ $(document).ready(function () {
           });
         }
         if (event && event.resp && event.resp.hasError) {
-          $('#product-availability').html('<i class="material-icons product-unavailable">&#xE14B;</i>' + event.resp.errors.join('<br/>'));
+          prestashop.emit('showErrorNextToAddtoCartButton', { errorMessage: event.resp.errors.join('<br/>')});
         }
       }
     );

--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -35,7 +35,7 @@ $(document).ready(function () {
       function (event) {
         var refreshURL = $('.blockcart').data('refresh-url');
         var requestData = {};
-        if (event && event.reason && !event.resp.hasError) {
+        if (event && event.reason && typeof event.resp !== 'undefined' && !event.resp.hasError) {
           requestData = {
             id_product_attribute: event.reason.idProductAttribute,
             id_product: event.reason.idProduct,


### PR DESCRIPTION
I've juste added a test to disable launching of showModal if the add to cart request (event) return an error.

EDIT: to be tested with https://github.com/PrestaShop/PrestaShop/pull/14033