### PR TITLE
Remove duplicate call to $(document).ready

### DIFF
--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -29,33 +29,31 @@ $(document).ready(function () {
     });
   };
 
-  $(document).ready(function () {
-    prestashop.on(
-      'updateCart',
-      function (event) {
-        var refreshURL = $('.blockcart').data('refresh-url');
-        var requestData = {};
-        if (event && event.reason && typeof event.resp !== 'undefined' && !event.resp.hasError) {
-          requestData = {
-            id_customization: event.reason.idCustomization,
-            id_product_attribute: event.reason.idProductAttribute,
-            id_product: event.reason.idProduct,
-            action: event.reason.linkAction
-          };
+  prestashop.on(
+    'updateCart',
+    function (event) {
+      var refreshURL = $('.blockcart').data('refresh-url');
+      var requestData = {};
+      if (event && event.reason && typeof event.resp !== 'undefined' && !event.resp.hasError) {
+        requestData = {
+          id_customization: event.reason.idCustomization,
+          id_product_attribute: event.reason.idProductAttribute,
+          id_product: event.reason.idProduct,
+          action: event.reason.linkAction
+        };
 
-          $.post(refreshURL, requestData).then(function (resp) {
-            $('.blockcart').replaceWith($(resp.preview).find('.blockcart'));
-            if (resp.modal) {
-              showModal(resp.modal);
-            }
-          }).fail(function (resp) {
-            prestashop.emit('handleError', { eventType: 'updateShoppingCart', resp: resp });
-          });
-        }
-        if (event && event.resp && event.resp.hasError) {
-          prestashop.emit('showErrorNextToAddtoCartButton', { errorMessage: event.resp.errors.join('<br/>')});
-        }
+        $.post(refreshURL, requestData).then(function (resp) {
+          $('.blockcart').replaceWith($(resp.preview).find('.blockcart'));
+          if (resp.modal) {
+            showModal(resp.modal);
+          }
+        }).fail(function (resp) {
+          prestashop.emit('handleError', { eventType: 'updateShoppingCart', resp: resp });
+        });
       }
-    );
-  });
+      if (event && event.resp && event.resp.hasError) {
+        prestashop.emit('showErrorNextToAddtoCartButton', { errorMessage: event.resp.errors.join('<br/>')});
+      }
+    }
+  );
 });


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This seemed to cause a bug for some users who could not reach the checkout page. This duplicate call would register the 'updateCart' event listener twice, therefore making 2 ajax post requests.
| Type?         | bugfix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Please check everything during the cart process works fine as we removed an unnecessary piece of code. 
