### PR TITLE
Clean modal template from old todos

### DIFF
--- a/modal.tpl
+++ b/modal.tpl
@@ -3,8 +3,6 @@
     <section>
       <h1>{l s='Product Successfully Added to Your Shopping Cart' d='Shop.Theme.Checkout'}</h1>
       {$product.name}
-      {*TODO: product image*}
-      {*TODO: cross-selling*}
     </section>
   </div>
 </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Clean modal template from old todos
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No need for QA

`{*TODO: product image*}`
=> I think we can remove it, the modal displays the product image so it's done ✅ 

`{*TODO: cross-selling*}`
=> I have no idea what this means, and consequently I guess we can remove it as it cannot trigger any action