### PR TITLE
Fix Cart total quantity refresh issue #16665 from module

### DIFF
--- a/ps_shoppingcart.js
+++ b/ps_shoppingcart.js
@@ -34,7 +34,7 @@ $(document).ready(function () {
     function (event) {
       var refreshURL = $('.blockcart').data('refresh-url');
       var requestData = {};
-      if (event && event.reason && typeof event.resp !== 'undefined' && !event.resp.hasError) {
+      if (event && event.reason && !('resp' in event)) {
         requestData = {
           id_customization: event.reason.idCustomization,
           id_product_attribute: event.reason.idProductAttribute,


### PR DESCRIPTION
Refresh cart preview even if `resp` key doesn't exist in emitted object.

Fixes: https://github.com/PrestaShop/PrestaShop/issues/16665

