### PR TITLE
Fix "On reset, module ps_shoppingcart is hooked in the wrong place"  issue #16968

### DIFF
--- a/ps_shoppingcart.php
+++ b/ps_shoppingcart.php
@@ -141,7 +141,7 @@ class Ps_Shoppingcart extends Module implements WidgetInterface
         return
             parent::install()
                 && $this->registerHook('header')
-                && $this->registerHook('displayTop')
+                && $this->registerHook('displayNav2')
                 && Configuration::updateValue('PS_BLOCK_CART_AJAX', 1);
     }
 


### PR DESCRIPTION
Modified the default registered hook  from `displayTop` to `displayNav2`. Now the default hook is the same in classic theme config and in module. Fixes [#16968](https://github.com/PrestaShop/PrestaShop/issues/16968)
 