### PR TITLE
Add crossselling hooks

### DIFF
--- a/modal.tpl
+++ b/modal.tpl
@@ -21,6 +21,8 @@
     <section>
       <h1>{l s='Product Successfully Added to Your Shopping Cart' d='Shop.Theme.Checkout'}</h1>
       {$product.name}
+      {hook h='displayCartModalContent' product=$product}
     </section>
+    {hook h='displayCartModalFooter' product=$product}
   </div>
 </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In order to mirror https://github.com/PrestaShop/PrestaShop/pull/20140, this PR adds two hooks to the modal that appears after adding product to cart. The bottom one can be used to display crosseling, the middle one to display special promotions or additional information.
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17709
| How to test?  | -
