### PR TITLE
Fix php notices while loading subtotals

### DIFF
--- a/ps_shoppingcart.tpl
+++ b/ps_shoppingcart.tpl
@@ -32,10 +32,12 @@
       </ul>
       <div class="cart-subtotals">
         {foreach from=$cart.subtotals item="subtotal"}
-          <div class="{$subtotal.type}">
-            <span class="label">{$subtotal.label}</span>
-            <span class="value">{$subtotal.amount}</span>
-          </div>
+          {if isset($subtotal.type, $subtotal.label, $subtotal.amount)}
+            <div class="{$subtotal.type}">
+              <span class="label">{$subtotal.label}</span>
+              <span class="value">{$subtotal.amount}</span>
+            </div>
+          {/if}
         {/foreach}
       </div>
       <div class="cart-total">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | https://github.com/PrestaShop/ps_shoppingcart/blob/5ecb9ae77bf58ab2e3254ebda76404425d2ac643/ps_shoppingcart.tpl#L34-L39 This will throw PHP notices since `$cart.subtotals.discounts` and `$cart.subtotals.tax` [can be null](https://github.com/PrestaShop/PrestaShop/blob/db334ee2069e946be7703cbca4b1168681d5a86b/src/Adapter/Presenter/Cart/CartPresenter.php#L338-L394)
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/27447
| How to test?  | Force your theme to load original files by removing/renaming `/themes/classic/modules/ps_shoppingcart/ps_shoppingcart.tpl`. Check php error_log before and after aplying this fix.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
`{$cart.subtotals|dump}`

![obraz](https://user-images.githubusercontent.com/5007456/150878678-09125494-2ef8-4c24-900a-93b8cad46253.png)


Although I think it would be better to always generate complete array in Prestashop's _/src/Adapter/Presenter/Cart/CartPresenter.php_ for `$cart.subtotals.discounts` and `$cart.subtotals.tax`, just like it is for `$cart.subtotals.products` when there's no product in the cart.
