### PR TITLE
Remove deprecated class, bump version, use already presented cart

### DIFF
--- a/.github/mktp-metadata.json
+++ b/.github/mktp-metadata.json
@@ -5,6 +5,6 @@
   "channel": "stable",
   "type_upgrade": "updatemin",
   "product_type": "module",
-  "compatible_from": "1.7.1.0",
+  "compatible_from": "1.7.5.0",
   "rgpd_status": "1"
 }

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.7.1.2', '1.7.2.5', '1.7.3.4', '1.7.4.4', '1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
+        presta-versions: ['1.7.5.1', '1.7.6', '1.7.7', '1.7.8', 'latest']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Display a shopping cart icon on your pages and the number of items it contains.
 
 ## Compatibility
 
-PrestaShop: `1.7.1.0` or later
+PrestaShop: `1.7.5.0` or later
 
 ## Multistore compatibility
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4"
+    "php": ">=5.6"
   },
   "require-dev": {
     "prestashop/php-dev-tools": "~3.0"

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_shoppingcart</name>
 	<displayName><![CDATA[Shopping cart]]></displayName>
-	<version><![CDATA[2.0.7]]></version>
+	<version><![CDATA[3.0.0]]></version>
 	<description><![CDATA[Adds a block containing the customer&#039;s shopping cart.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[front_office_features]]></tab>

--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -35,9 +35,8 @@ class Ps_ShoppingcartAjaxModuleFrontController extends ModuleFrontController
 
         $modal = null;
 
-        if ($this->module instanceof Ps_Shoppingcart && Tools::getValue('action') === 'add-to-cart') {
+        if (Tools::getValue('action') === 'add-to-cart') {
             $modal = $this->module->renderModal(
-                $this->context->cart,
                 (int) Tools::getValue('id_product'),
                 (int) Tools::getValue('id_product_attribute'),
                 (int) Tools::getValue('id_customization')
@@ -47,7 +46,7 @@ class Ps_ShoppingcartAjaxModuleFrontController extends ModuleFrontController
         ob_end_clean();
         header('Content-Type: application/json');
         exit(json_encode([
-            'preview' => $this->module instanceof Ps_Shoppingcart ? $this->module->renderWidget(null, ['cart' => $this->context->cart]) : '',
+            'preview' => $this->module->renderWidget(null, []),
             'modal' => $modal,
         ]));
     }

--- a/ps_shoppingcart.php
+++ b/ps_shoppingcart.php
@@ -137,7 +137,6 @@ class Ps_Shoppingcart extends Module implements WidgetInterface
     }
 
     /**
-     * @param Cart $cart
      * @param int $id_product
      * @param int $id_product_attribute
      * @param int $id_customization

--- a/ps_shoppingcart.php
+++ b/ps_shoppingcart.php
@@ -103,7 +103,8 @@ class Ps_Shoppingcart extends Module implements WidgetInterface
      *
      * @return array presented cart
      */
-    private function getPresentedCart() {
+    private function getPresentedCart()
+    {
         /*
          * We will use the already presented cart in the first place. It should be already in the template.
          * Check FrontController::assignGeneralPurposeVariables for more information.

--- a/tests/phpstan/phpstan-1.7.1.0.neon
+++ b/tests/phpstan/phpstan-1.7.1.0.neon
@@ -1,6 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method assign\(\) on an unknown class Smarty_Data#'

--- a/tests/phpstan/phpstan-1.7.1.2.neon
+++ b/tests/phpstan/phpstan-1.7.1.2.neon
@@ -1,6 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method assign\(\) on an unknown class Smarty_Data#'

--- a/tests/phpstan/phpstan-1.7.2.5.neon
+++ b/tests/phpstan/phpstan-1.7.2.5.neon
@@ -1,6 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method assign\(\) on an unknown class Smarty_Data#'

--- a/tests/phpstan/phpstan-1.7.3.4.neon
+++ b/tests/phpstan/phpstan-1.7.3.4.neon
@@ -1,6 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method assign\(\) on an unknown class Smarty_Data#'

--- a/tests/phpstan/phpstan-1.7.4.4.neon
+++ b/tests/phpstan/phpstan-1.7.4.4.neon
@@ -1,2 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/phpstan/phpstan.neon

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -9,6 +9,6 @@ parameters:
     - ../../translations/
     - ../../upgrade/
   ignoreErrors:
-    - '#Call to an undefined method Module::renderModal().#'
-    - '#Call to an undefined method Module::renderWidget().#'
+    - '#Call to an undefined method Module::renderModal\(\).#'
+    - '#Call to an undefined method Module::renderWidget\(\).#'
   level: 5

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -8,4 +8,7 @@ parameters:
     - ../../controllers/
     - ../../translations/
     - ../../upgrade/
+  ignoreErrors:
+    - '#Call to an undefined method Module::renderModal().#'
+    - '#Call to an undefined method Module::renderWidget().#'
   level: 5


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | See below
| Type?         | refacto
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Check that everything works normally and you can add products to cart just fine.

### Description
- Removes the usage of deprecated class of `PrestaShop\PrestaShop\Adapter\Cart\CartPresenter`. So I can remove it in https://github.com/PrestaShop/PrestaShop/pull/34525.
- Bumps minimal version to 1.7.5 because that's the version were it got moved into the new location.
- Bumps version of module to 3.0.0.
- Uses the presented cart from front controller if set.
  - This will save us a lot of load time, because it doesn't have to run the extreme performance intensive presenting.
  - Also, it will copy the gift/nongift presenting used in the core.
  - If for some reason it's not in smarty, we will present it ourselves, but this should never happen normally, so it's just a safety precaution.
- Added some ignored tests instead of checking for instance of this module during runtime.

### Real world speed improvement on 1.7.6.9
![before](https://github.com/PrestaShop/ps_shoppingcart/assets/6097524/77b2c944-4c93-403c-90f2-24682e6f4ee2)
⏬⏬⏬
![after](https://github.com/PrestaShop/ps_shoppingcart/assets/6097524/7e0183ea-1f7e-4dd8-9fc0-43842fef85d9)
